### PR TITLE
Change the default maxHeightBorder's value for small top height.

### DIFF
--- a/QMBParallaxScrollViewController/QMBParallaxScrollViewController.h
+++ b/QMBParallaxScrollViewController/QMBParallaxScrollViewController.h
@@ -64,7 +64,7 @@ typedef NS_ENUM(NSUInteger, QMBParallaxGesture) {
 
 /**
  * Set the height of the border (margin from top) that has to be scrolled over to expand the background view.
- * Default: 1.3 * topHeight
+ * Default: MAX(1.5f * _topHeight, 300.0f)
  */
 @property (nonatomic, assign, setter = setMaxHeightBorder:) CGFloat maxHeightBorder;
 

--- a/QMBParallaxScrollViewController/QMBParallaxScrollViewController.m
+++ b/QMBParallaxScrollViewController/QMBParallaxScrollViewController.m
@@ -58,7 +58,7 @@
     _topHeight = height;
     _startTopHeight = _topHeight;
     _maxHeight = self.view.frame.size.height-50.0f;
-    [self setMaxHeightBorder:1.5f*_topHeight];
+    [self setMaxHeightBorder:MAX(1.5f*_topHeight, 300.0f)];
     [self setMinHeightBorder:_maxHeight-20.0f];
     
     [self addChildViewController:self.topViewController];


### PR DESCRIPTION
Change the default value of maxHeightBorder so it triggers less easily the fullscreen mode. Especially when the top height is less than 200px.
