### PR TITLE
Fix bug when coming back from fullscreen

### DIFF
--- a/QMBParallaxScrollViewController/QMBParallaxScrollViewController.m
+++ b/QMBParallaxScrollViewController/QMBParallaxScrollViewController.m
@@ -28,6 +28,10 @@
 @property (nonatomic, strong, readwrite) UIViewController<QMBParallaxScrollViewHolder> * bottomViewController;
 
 @property (nonatomic, assign, readwrite) CGFloat topHeight;
+
+@property (nonatomic, assign, readwrite) CGFloat initialMaxHeightBorder;
+@property (nonatomic, assign, readwrite) CGFloat initialMinHeightBorder;
+
 @property (nonatomic, readwrite) QMBParallaxState state;
 @property (nonatomic, readwrite) QMBParallaxGesture lastGesture;
 
@@ -255,17 +259,18 @@
                          
                          if (self.state == QMBParallaxStateFullSize){
                              self.state = QMBParallaxStateVisible;
-                         }else {
+                             self.maxHeightBorder = self.initialMaxHeightBorder;
+                         } else {
                              self.state = QMBParallaxStateFullSize;
+                             self.minHeightBorder = self.initialMinHeightBorder;
                          }
                          
                          if ([self.delegate respondsToSelector:@selector(parallaxScrollViewController:didChangeState:)]){
                              [self.delegate parallaxScrollViewController:self didChangeState:self.state];
                          }
                      }];
-    
-    
 }
+
 
 - (void) changeTopHeight:(CGFloat) height{
     
@@ -282,15 +287,13 @@
 #pragma mark - Borders
 
 - (void)setMaxHeightBorder:(CGFloat)maxHeightBorder{
-    
     _maxHeightBorder = MAX(_topHeight,maxHeightBorder);
-    
+    self.initialMaxHeightBorder = maxHeightBorder;
 }
 
 - (void)setMinHeightBorder:(CGFloat)minHeightBorder{
-    
     _minHeightBorder = MIN(_maxHeight,minHeightBorder);
-    
+    self.initialMinHeightBorder = minHeightBorder;
 }
 
 @end


### PR DESCRIPTION
I set a custom maxHeightBorder and it worked fine. But after the top view was displayed in fullscreen, this value was overridden and never got back. 

To fix this issue, I added self.initialMaxHeightBorder and initialMinHeightBorder to QMBParallaxScrollViewController, in order be sure the behaviour is kept even after a change of state.
