### PR TITLE
place background view behind the foreground view when inserting subviews

### DIFF
--- a/QMBParallaxScrollViewController/QMBParallaxScrollViewController.m
+++ b/QMBParallaxScrollViewController/QMBParallaxScrollViewController.m
@@ -95,7 +95,7 @@
     [self.view addSubview:_foregroundScrollView];
     [self.bottomViewController didMoveToParentViewController:self];
     
-    [self.view addSubview:_backgroundView];
+    [self.view insertSubview:_backgroundView belowSubview:_foregroundScrollView];
     [self.topViewController didMoveToParentViewController:self];
     
     [self addGestureReconizer];


### PR DESCRIPTION
I a using QMBParallaxScrollViewController almost identically to your 'Map View Example'. I wanted to create a partially transparent overlay that would sit on top of my map (the `backgroundView`) and which would be a part of and would scroll with my `foregroundScrollView`. The `backgoundView` was in fact being inserted above the `foregroundScrollView`, so my image overlay was sitting behind the map instead of on top of it. This simple change fixes that and allows people to have content in their `foregroundScrollView` that sits on top of their `backgroundView`.
