### PR TITLE
Fixes view controller resizing & animation frame resizing. 

### DIFF
--- a/QMBParallaxScrollViewController/QMBParallaxScrollViewController.m
+++ b/QMBParallaxScrollViewController/QMBParallaxScrollViewController.m
@@ -275,7 +275,7 @@
     
     [UIView animateWithDuration:.3
                           delay:0.0
-                        options:UIViewAnimationOptionCurveEaseInOut|UIViewKeyframeAnimationOptionBeginFromCurrentState
+                        options:UIViewAnimationOptionCurveEaseInOut|UIViewKeyframeAnimationOptionBeginFromCurrentState|UIViewAnimationOptionLayoutSubviews
                      animations:^{
                          
                          [self changeTopHeight:show ?  _maxHeight : _startTopHeight];

--- a/QMBParallaxScrollViewController/QMBParallaxScrollViewController.m
+++ b/QMBParallaxScrollViewController/QMBParallaxScrollViewController.m
@@ -90,6 +90,7 @@
     _foregroundScrollView.delegate = self;
     [_foregroundScrollView setAlwaysBounceVertical:YES];
     _foregroundScrollView.frame = self.view.frame;
+    _foregroundScrollView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     [_foregroundScrollView addSubview:_foregroundView];
     
     [self.view addSubview:_foregroundScrollView];


### PR DESCRIPTION
When animating the top view my views were jumping between states & not animating nicely.
I also found that when the view controller was resized (which is common when using non-extended edges layout) the scrollview would sit out of bounds. 
