### PR TITLE
Revert "place background view behind the foreground view when inserting ...

### DIFF
--- a/QMBParallaxScrollViewController/QMBParallaxScrollViewController.m
+++ b/QMBParallaxScrollViewController/QMBParallaxScrollViewController.m
@@ -96,7 +96,7 @@
     [self.view addSubview:_foregroundScrollView];
     [self.bottomViewController didMoveToParentViewController:self];
     
-    [self.view insertSubview:_backgroundView belowSubview:_foregroundScrollView];
+    [self.view addSubview:_backgroundView];
     [self.topViewController didMoveToParentViewController:self];
     
     [self addGestureReconizer];


### PR DESCRIPTION
Reverts quemb/QMBParallaxScrollViewController#16

After merging it, I remembered why I choose to place the _backgroundView on top of the _foregroundScrollView. Even though it sounds strange, but I needed user interaction on the _backgroundView. And because you need user interaction enabled on the _foregroundScrollView, the background view needs to be on top.

But I can image to implement a config option for that.. 
